### PR TITLE
add dark/light mode to all pages

### DIFF
--- a/client/src/ThemeContext.jsx
+++ b/client/src/ThemeContext.jsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const ThemeContext = createContext();
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(
+    () => localStorage.getItem("theme") || "light"
+  );
+
+  useEffect(() => {
+    // Remove both classes, then add the right one
+    document.documentElement.classList.remove("light", "dark");
+    document.documentElement.classList.add(theme);
+
+    // Set body background and text color using CSS variables
+    document.body.style.background = "var(--bg-main)";
+    document.body.style.color = "var(--text-main)";
+
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () =>
+    setTheme((prev) => (prev === "light" ? "dark" : "light"));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/client/src/components/Landing/About.jsx
+++ b/client/src/components/Landing/About.jsx
@@ -2,10 +2,17 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { FaTint, FaHandHoldingHeart, FaShieldAlt, FaMapMarkerAlt, FaUsers, FaHeartbeat } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
+
 const About = () => {
   const navigate = useNavigate();
   return (
-    <div className="min-h-screen bg-gradient-to-br from-[#fdf2f8] to-[#f0f9ff] py-30 px-4 sm:px-6 lg:px-8">
+    <div
+      className="min-h-screen py-30 px-4 sm:px-6 lg:px-8"
+      style={{
+        background: "var(--bg-main)",
+        color: "var(--text-main)"
+      }}
+    >
       <div className="max-w-7xl mx-auto">
         {/* Hero Section */}
         <motion.div 
@@ -33,7 +40,8 @@ const About = () => {
           </motion.h1>
           
           <motion.p
-            className="text-xl text-gray-700 max-w-3xl mx-auto"
+            className="text-xl max-w-3xl mx-auto"
+            style={{ color: "var(--text-muted)" }}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 0.4 }}
@@ -49,24 +57,52 @@ const About = () => {
           animate={{ opacity: 1 }}
           transition={{ delay: 0.6 }}
         >
-          <div className="bg-white rounded-2xl p-6 text-center shadow-xl border border-gray-100">
-            <div className="text-4xl font-bold text-red-600">50K+</div>
-            <div className="text-gray-600 mt-2">Lives Saved</div>
+          <div
+            className="rounded-2xl p-6 text-center shadow-xl border"
+            style={{
+              background: "var(--bg-surface)",
+              borderColor: "rgba(200,0,0,0.08)",
+              color: "var(--text-main)"
+            }}
+          >
+            <div className="text-4xl font-bold" style={{ color: "var(--accent)" }}>50K+</div>
+            <div className="mt-2" style={{ color: "var(--text-muted)" }}>Lives Saved</div>
           </div>
           
-          <div className="bg-white rounded-2xl p-6 text-center shadow-xl border border-gray-100">
-            <div className="text-4xl font-bold text-red-600">120K+</div>
-            <div className="text-gray-600 mt-2">Donors</div>
+          <div
+            className="rounded-2xl p-6 text-center shadow-xl border"
+            style={{
+              background: "var(--bg-surface)",
+              borderColor: "rgba(200,0,0,0.08)",
+              color: "var(--text-main)"
+            }}
+          >
+            <div className="text-4xl font-bold" style={{ color: "var(--accent)" }}>120K+</div>
+            <div className="mt-2" style={{ color: "var(--text-muted)" }}>Donors</div>
           </div>
           
-          <div className="bg-white rounded-2xl p-6 text-center shadow-xl border border-gray-100">
-            <div className="text-4xl font-bold text-red-600">500+</div>
-            <div className="text-gray-600 mt-2">Hospitals</div>
+          <div
+            className="rounded-2xl p-6 text-center shadow-xl border"
+            style={{
+              background: "var(--bg-surface)",
+              borderColor: "rgba(200,0,0,0.08)",
+              color: "var(--text-main)"
+            }}
+          >
+            <div className="text-4xl font-bold" style={{ color: "var(--accent)" }}>500+</div>
+            <div className="mt-2" style={{ color: "var(--text-muted)" }}>Hospitals</div>
           </div>
           
-          <div className="bg-white rounded-2xl p-6 text-center shadow-xl border border-gray-100">
-            <div className="text-4xl font-bold text-red-600">98%</div>
-            <div className="text-gray-600 mt-2">Success Rate</div>
+          <div
+            className="rounded-2xl p-6 text-center shadow-xl border"
+            style={{
+              background: "var(--bg-surface)",
+              borderColor: "rgba(200,0,0,0.08)",
+              color: "var(--text-main)"
+            }}
+          >
+            <div className="text-4xl font-bold" style={{ color: "var(--accent)" }}>98%</div>
+            <div className="mt-2" style={{ color: "var(--text-muted)" }}>Success Rate</div>
           </div>
         </motion.div>
 
@@ -77,7 +113,12 @@ const About = () => {
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.8 }}
         >
-          <div className="relative bg-gradient-to-r from-red-500 to-pink-600 rounded-3xl shadow-2xl overflow-hidden">
+          <div
+            className="relative bg-gradient-to-r from-red-500 to-pink-600 rounded-3xl shadow-2xl overflow-hidden"
+            style={{
+              background: "linear-gradient(to right, #ef4444, #ec4899)"
+            }}
+          >
             <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MCIgaGVpZ2h0PSI2MCIgdmlld0JveD0iMCAwIDYwIDYwIj48Y2lyY2xlIGN4PSIyMCIgY3k9IjIwIiByPSIxIiBmaWxsPSJ3aGl0ZSIgZmlsbC1vcGFjaXR5PSIwLjEiLz48L3N2Zz4=')] opacity-20"></div>
             <div className="relative z-10 p-10 md:p-16">
               <h2 className="text-3xl md:text-4xl font-bold text-white mb-6 text-center">Our Mission</h2>
@@ -93,7 +134,8 @@ const About = () => {
         {/* Features Section */}
         <div className="mb-20">
           <motion.h2 
-            className="text-3xl font-bold text-center mb-16 text-gray-800"
+            className="text-3xl font-bold text-center mb-16"
+            style={{ color: "var(--text-main)" }}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 1 }}
@@ -104,7 +146,12 @@ const About = () => {
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
             <motion.div 
               whileHover={{ scale: 1.05, y: -10 }}
-              className="bg-white p-8 rounded-3xl shadow-xl border border-gray-100 flex flex-col items-center text-center"
+              className="p-8 rounded-3xl shadow-xl border flex flex-col items-center text-center"
+              style={{
+                background: "var(--bg-surface)",
+                borderColor: "rgba(200,0,0,0.08)",
+                color: "var(--text-main)"
+              }}
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 1.2 }}
@@ -112,15 +159,20 @@ const About = () => {
               <div className="bg-red-100 w-20 h-20 rounded-full flex items-center justify-center mb-6">
                 <FaTint className="text-red-600 text-3xl" />
               </div>
-              <h3 className="text-xl font-bold mb-3 text-gray-800">Simplified Donation</h3>
-              <p className="text-gray-600">
+              <h3 className="text-xl font-bold mb-3" style={{ color: "var(--text-main)" }}>Simplified Donation</h3>
+              <p style={{ color: "var(--text-muted)" }}>
                 Intuitive platform connecting donors with verified blood banks and hospitals
               </p>
             </motion.div>
 
             <motion.div 
               whileHover={{ scale: 1.05, y: -10 }}
-              className="bg-white p-8 rounded-3xl shadow-xl border border-gray-100 flex flex-col items-center text-center"
+              className="p-8 rounded-3xl shadow-xl border flex flex-col items-center text-center"
+              style={{
+                background: "var(--bg-surface)",
+                borderColor: "rgba(200,0,0,0.08)",
+                color: "var(--text-main)"
+              }}
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 1.4 }}
@@ -128,15 +180,20 @@ const About = () => {
               <div className="bg-pink-100 w-20 h-20 rounded-full flex items-center justify-center mb-6">
                 <FaHandHoldingHeart className="text-pink-600 text-3xl" />
               </div>
-              <h3 className="text-xl font-bold mb-3 text-gray-800">Community Driven</h3>
-              <p className="text-gray-600">
+              <h3 className="text-xl font-bold mb-3" style={{ color: "var(--text-main)" }}>Community Driven</h3>
+              <p style={{ color: "var(--text-muted)" }}>
                 Powered by compassionate donors committed to saving lives daily
               </p>
             </motion.div>
 
             <motion.div 
               whileHover={{ scale: 1.05, y: -10 }}
-              className="bg-white p-8 rounded-3xl shadow-xl border border-gray-100 flex flex-col items-center text-center"
+              className="p-8 rounded-3xl shadow-xl border flex flex-col items-center text-center"
+              style={{
+                background: "var(--bg-surface)",
+                borderColor: "rgba(200,0,0,0.08)",
+                color: "var(--text-main)"
+              }}
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 1.6 }}
@@ -144,15 +201,20 @@ const About = () => {
               <div className="bg-blue-100 w-20 h-20 rounded-full flex items-center justify-center mb-6">
                 <FaShieldAlt className="text-blue-600 text-3xl" />
               </div>
-              <h3 className="text-xl font-bold mb-3 text-gray-800">Safe & Verified</h3>
-              <p className="text-gray-600">
+              <h3 className="text-xl font-bold mb-3" style={{ color: "var(--text-main)" }}>Safe & Verified</h3>
+              <p style={{ color: "var(--text-muted)" }}>
                 Rigorous screening and quality control for all donations
               </p>
             </motion.div>
 
             <motion.div 
               whileHover={{ scale: 1.05, y: -10 }}
-              className="bg-white p-8 rounded-3xl shadow-xl border border-gray-100 flex flex-col items-center text-center"
+              className="p-8 rounded-3xl shadow-xl border flex flex-col items-center text-center"
+              style={{
+                background: "var(--bg-surface)",
+                borderColor: "rgba(200,0,0,0.08)",
+                color: "var(--text-main)"
+              }}
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 1.8 }}
@@ -160,15 +222,20 @@ const About = () => {
               <div className="bg-purple-100 w-20 h-20 rounded-full flex items-center justify-center mb-6">
                 <FaMapMarkerAlt className="text-purple-600 text-3xl" />
               </div>
-              <h3 className="text-xl font-bold mb-3 text-gray-800">Location Tracking</h3>
-              <p className="text-gray-600">
+              <h3 className="text-xl font-bold mb-3" style={{ color: "var(--text-main)" }}>Location Tracking</h3>
+              <p style={{ color: "var(--text-muted)" }}>
                 Find the nearest donation centers with real-time availability
               </p>
             </motion.div>
 
             <motion.div 
               whileHover={{ scale: 1.05, y: -10 }}
-              className="bg-white p-8 rounded-3xl shadow-xl border border-gray-100 flex flex-col items-center text-center"
+              className="p-8 rounded-3xl shadow-xl border flex flex-col items-center text-center"
+              style={{
+                background: "var(--bg-surface)",
+                borderColor: "rgba(200,0,0,0.08)",
+                color: "var(--text-main)"
+              }}
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 2.0 }}
@@ -176,15 +243,20 @@ const About = () => {
               <div className="bg-green-100 w-20 h-20 rounded-full flex items-center justify-center mb-6">
                 <FaUsers className="text-green-600 text-3xl" />
               </div>
-              <h3 className="text-xl font-bold mb-3 text-gray-800">Donor Network</h3>
-              <p className="text-gray-600">
+              <h3 className="text-xl font-bold mb-3" style={{ color: "var(--text-main)" }}>Donor Network</h3>
+              <p style={{ color: "var(--text-muted)" }}>
                 Connect with other donors and organize community drives
               </p>
             </motion.div>
 
             <motion.div 
               whileHover={{ scale: 1.05, y: -10 }}
-              className="bg-white p-8 rounded-3xl shadow-xl border border-gray-100 flex flex-col items-center text-center"
+              className="p-8 rounded-3xl shadow-xl border flex flex-col items-center text-center"
+              style={{
+                background: "var(--bg-surface)",
+                borderColor: "rgba(200,0,0,0.08)",
+                color: "var(--text-main)"
+              }}
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 2.2 }}
@@ -192,8 +264,8 @@ const About = () => {
               <div className="bg-amber-100 w-20 h-20 rounded-full flex items-center justify-center mb-6">
                 <FaHeartbeat className="text-amber-600 text-3xl" />
               </div>
-              <h3 className="text-xl font-bold mb-3 text-gray-800">Health Tracking</h3>
-              <p className="text-gray-600">
+              <h3 className="text-xl font-bold mb-3" style={{ color: "var(--text-main)" }}>Health Tracking</h3>
+              <p style={{ color: "var(--text-muted)" }}>
                 Monitor your donation history and health impact
               </p>
             </motion.div>
@@ -202,15 +274,19 @@ const About = () => {
 
         {/* CTA Section */}
         <motion.div 
-          className="mt-16 bg-gradient-to-r from-red-500 to-pink-600 rounded-3xl p-10 text-center shadow-2xl"
+          className="mt-16 rounded-3xl p-10 text-center shadow-2xl"
+          style={{
+            background: "linear-gradient(to right, #ef4444, #ec4899)",
+            color: "#fff"
+          }}
           initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 2.4 }}
         >
-          <h2 className="text-3xl font-bold text-white mb-6">
+          <h2 className="text-3xl font-bold mb-6">
             Join Our Life-Saving Community
           </h2>
-          <p className="text-xl text-white max-w-2xl mx-auto mb-8">
+          <p className="text-xl max-w-2xl mx-auto mb-8">
             Every donation matters. Become part of a network that's saved thousands of lives 
             and continues to make a difference daily.
           </p>
@@ -244,45 +320,63 @@ const About = () => {
           animate={{ opacity: 1 }}
           transition={{ delay: 2.6 }}
         >
-          <h2 className="text-3xl font-bold text-center mb-12 text-gray-800">Donor Stories</h2>
+          <h2 className="text-3xl font-bold text-center mb-12" style={{ color: "var(--text-main)" }}>Donor Stories</h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <div className="bg-white rounded-3xl p-8 shadow-lg">
+            <div
+              className="rounded-3xl p-8 shadow-lg"
+              style={{
+                background: "var(--bg-surface)",
+                color: "var(--text-main)"
+              }}
+            >
               <div className="flex items-center mb-6">
                 <div className="bg-gray-200 border-2 border-dashed rounded-xl w-16 h-16" />
                 <div className="ml-4">
-                  <h4 className="font-bold text-gray-800">Sarah Johnson</h4>
-                  <p className="text-gray-600">Regular donor for 5 years</p>
+                  <h4 className="font-bold" style={{ color: "var(--text-main)" }}>Sarah Johnson</h4>
+                  <p className="" style={{ color: "var(--text-muted)" }}>Regular donor for 5 years</p>
                 </div>
               </div>
-              <p className="text-gray-700 italic">
+              <p className="italic" style={{ color: "var(--text-main)" }}>
                 "This platform made it so easy to find where my blood type was needed most. 
                 I've donated 12 times through this app and saved multiple lives!"
               </p>
             </div>
             
-            <div className="bg-white rounded-3xl p-8 shadow-lg">
+            <div
+              className="rounded-3xl p-8 shadow-lg"
+              style={{
+                background: "var(--bg-surface)",
+                color: "var(--text-main)"
+              }}
+            >
               <div className="flex items-center mb-6">
                 <div className="bg-gray-200 border-2 border-dashed rounded-xl w-16 h-16" />
                 <div className="ml-4">
-                  <h4 className="font-bold text-gray-800">Michael Chen</h4>
-                  <p className="text-gray-600">Blood recipient</p>
+                  <h4 className="font-bold" style={{ color: "var(--text-main)" }}>Michael Chen</h4>
+                  <p style={{ color: "var(--text-muted)" }}>Blood recipient</p>
                 </div>
               </div>
-              <p className="text-gray-700 italic">
+              <p className="italic" style={{ color: "var(--text-main)" }}>
                 "When I needed an emergency transfusion, this network found a matching donor 
                 in just 2 hours. I owe my life to this incredible community."
               </p>
             </div>
             
-            <div className="bg-white rounded-3xl p-8 shadow-lg">
+            <div
+              className="rounded-3xl p-8 shadow-lg"
+              style={{
+                background: "var(--bg-surface)",
+                color: "var(--text-main)"
+              }}
+            >
               <div className="flex items-center mb-6">
                 <div className="bg-gray-200 border-2 border-dashed rounded-xl w-16 h-16" />
                 <div className="ml-4">
-                  <h4 className="font-bold text-gray-800">Dr. Anika Patel</h4>
-                  <p className="text-gray-600">Hospital Administrator</p>
+                  <h4 className="font-bold" style={{ color: "var(--text-main)" }}>Dr. Anika Patel</h4>
+                  <p style={{ color: "var(--text-muted)" }}>Hospital Administrator</p>
                 </div>
               </div>
-              <p className="text-gray-700 italic">
+              <p className="italic" style={{ color: "var(--text-main)" }}>
                 "Our hospital has reduced blood shortage emergencies by 75% since joining 
                 this platform. The real-time donor matching is revolutionary."
               </p>

--- a/client/src/components/Landing/BloodBank.jsx
+++ b/client/src/components/Landing/BloodBank.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import { Icon } from 'leaflet';
-import { FaClock, FaPhone, FaMapMarkerAlt, FaSearch, FaHeart, FaTint,FaArrowLeft } from 'react-icons/fa';
+import { FaClock, FaPhone, FaMapMarkerAlt, FaSearch, FaHeart, FaTint, FaArrowLeft } from 'react-icons/fa';
 import PropTypes from 'prop-types';
 
 const INDIA_CENTER = [20.5937, 78.9629];
@@ -41,106 +41,8 @@ const BloodBankLocator = () => {
   const [mapZoom, setMapZoom] = useState(DEFAULT_ZOOM);
   const [hasSearched, setHasSearched] = useState(false);
 
-  // Sample blood banks database for India (expanded dataset)
-  const bloodBanksDatabase = [
-    // Delhi
-    { name: "Safdarjung Hospital Blood Bank", city: "Delhi", state: "Delhi", lat: 28.5763, lng: 77.2100, hours: "24/7", contact: "011-2610-6666", address: "Safdarjung Enclave, New Delhi" },
-    { name: "Lady Hardinge Medical College Blood Bank", city: "Delhi", state: "Delhi", lat: 28.5890, lng: 77.2050, hours: "9 AM - 6 PM", contact: "011-2436-6681", address: "Bahadur Shah Zafar Marg, New Delhi" },
-    { name: "Deep Chand Bandhu Hospital Blood Bank", city: "Delhi", state: "Delhi", lat: 28.6657, lng: 77.2545, hours: "8 AM - 8 PM", contact: "011-2297-8554", address: "Shahdara, Delhi" },
-    { name: "Deen Dayal Upadhyay Hospital Blood Bank", city: "Delhi", state: "Delhi", lat: 28.7201, lng: 77.2580, hours: "24/7", contact: "011-2239-6414", address: "Shivaji Marg, New Delhi" },
-    { name: "GTB Hospital Blood Bank", city: "Delhi", state: "Delhi", lat: 28.6672, lng: 77.2195, hours: "24/7", contact: "011-2356-1824", address: "Wazirabad Road, New Delhi" },
-    { name: "AIIMS Blood Bank", city: "Delhi", state: "Delhi", lat: 28.5880, lng: 77.1980, hours: "24/7", contact: "011-2658-8500", address: "Ansari Nagar, New Delhi" },
-    // Mumbai
-    { name: "Tata Memorial Hospital Blood Bank", city: "Mumbai", state: "Maharashtra", lat: 19.0176, lng: 72.8561, hours: "24/7", contact: "022-2417-7000", address: "Dr. E Borges Road, Parel, Mumbai" },
-    { name: "KEM Hospital Blood Bank", city: "Mumbai", state: "Maharashtra", lat: 18.9889, lng: 72.8317, hours: "24/7", contact: "022-2410-7000", address: "489, Rasta Peth, Pune Road, Mumbai" },
-    { name: "Sir JJ Hospital Blood Bank", city: "Mumbai", state: "Maharashtra", lat: 18.9560, lng: 72.8258, hours: "24/7", contact: "022-2302-3700", address: "Byculla East, Mumbai" },
-    { name: "Fortis Hospital Blood Bank", city: "Mumbai", state: "Maharashtra", lat: 19.1180, lng: 72.8430, hours: "24/7", contact: "022-4131-3131", address: "Mulund West, Mumbai" },
-    { name: "Kokilaben Dhirubhai Ambani Hospital Blood Bank", city: "Mumbai", state: "Maharashtra", lat: 19.0770, lng: 72.8408, hours: "24/7", contact: "022-3096-6000", address: "Andheri West, Mumbai" },
-    { name: "Hinduja Hospital Blood Bank", city: "Mumbai", state: "Maharashtra", lat: 19.1185, lng: 72.8562, hours: "24/7", contact: "022-2373-6666", address: "Mahim Junction, Mumbai" },
-    { name: "Jaslok Hospital Blood Bank", city: "Mumbai", state: "Maharashtra", lat: 18.9938, lng: 72.8172, hours: "24/7", contact: "022-6656-4444", address: "Pedder Road, Mumbai" },
-
-    
-    // Kolkata
-    { name: "Medical College Hospital Blood Bank", city: "Kolkata", state: "West Bengal", lat: 22.5726, lng: 88.3639, hours: "24/7", contact: "033-2241-3106", address: "88, College Street, Kolkata" },
-    { name: "SSKM Hospital Blood Bank", city: "Kolkata", state: "West Bengal", lat: 22.5410, lng: 88.3468, hours: "24/7", contact: "033-2204-1000", address: "244, AJC Bose Road, Kolkata" },
-    { name: "Belle Vue Clinic Blood Bank", city: "Kolkata", state: "West Bengal", lat: 22.5370, lng: 88.3545, hours: "9 AM - 5 PM", contact: "033-2287-4081", address: "36, Ballygunge Circular Road, Kolkata" },
-    { name: "Apollo Gleneagles Blood Bank", city: "Kolkata", state: "West Bengal", lat: 22.5711, lng: 88.4004, hours: "24/7", contact: "033-3988-5050", address: "58B, Canal Circular Road, Kolkata" },
-    { name: "Woodland Blood Bank", city: "Kolkata", state: "West Bengal", lat: 22.5037, lng: 88.3235, hours: "8 AM - 8 PM", contact: "033-2454-6267", address: "25, Russell Street, Kolkata" },
-    { name: "AMRI Hospital Blood Bank", city: "Kolkata", state: "West Bengal", lat: 22.5645, lng: 88.3436, hours: "24/7", contact: "033-4026-6500", address: "1, AJC Bose Road, Kolkata" },
-    { name: "National Medical College Blood Bank", city: "Kolkata", state: "West Bengal", lat: 22.5332, lng: 88.3604, hours: "24/7", contact: "033-2223-9232", address: "91, S P Mukherjee Road, Kolkata" },
-
-    // Chennai
-    { name: "Apollo Hospital Blood Bank", city: "Chennai", state: "Tamil Nadu", lat: 13.0358, lng: 80.2297, hours: "24/7", contact: "044-2829-3333", address: "21, Greams Lane, Off Greams Road, Chennai" },
-    { name: "Government General Hospital Blood Bank", city: "Chennai", state: "Tamil Nadu", lat: 13.0878, lng: 80.2785, hours: "24/7", contact: "044-2819-3000", address: "EVR Periyar Salai, Park Town, Chennai" },
-    { name: "Stanley Medical College Blood Bank", city: "Chennai", state: "Tamil Nadu", lat: 13.0858, lng: 80.2812, hours: "24/7", contact: "044-2560-5544", address: "Poonamallee High Road, Chennai" },
-    { name: "Sri Ramachandra Medical College Blood Bank", city: "Chennai", state: "Tamil Nadu", lat: 13.0103, lng: 80.2552, hours: "24/7", contact: "044-2747-1444", address: "Porur, Chennai" },
-    { name: "Madras Medical College Blood Bank", city: "Chennai", state: "Tamil Nadu", lat: 13.0638, lng: 80.2613, hours: "24/7", contact: "044-2530-1492", address: "Park Town, Chennai" },
-    { name: "Dr. Rela Institute Blood Bank", city: "Chennai", state: "Tamil Nadu", lat: 12.9718, lng: 80.1995, hours: "24/7", contact: "044-4901-3333", address: "Chromepet, Chennai" },
-    { name: "SRM Hospital Blood Bank", city: "Chennai", state: "Tamil Nadu", lat: 12.8275, lng: 80.0413, hours: "24/7", contact: "044-2745-0100", address: "Kattankulathur, Chennai" },
-
-    // Bangalore
-    { name: "Nimhans Blood Bank", city: "Bangalore", state: "Karnataka", lat: 12.9435, lng: 77.5962, hours: "24/7", contact: "080-2699-5745", address: "Hosur Road, Bangalore" },
-    { name: "Victoria Hospital Blood Bank", city: "Bangalore", state: "Karnataka", lat: 12.9698, lng: 77.5986, hours: "8 AM - 8 PM", contact: "080-2670-1150", address: "Fort, Bangalore Medical College Road, Bangalore" },
-    { name: "Fortis Hospital Blood Bank", city: "Bangalore", state: "Karnataka", lat: 12.9716, lng: 77.5760, hours: "24/7", contact: "080-2558-4333", address: "Bannerghatta Road, Bangalore" },
-    { name: "Manipal Hospital Blood Bank", city: "Bangalore", state: "Karnataka", lat: 12.9430, lng: 77.5500, hours: "24/7", contact: "080-6760-1234", address: "Old Airport Road, Bangalore" },
-    { name: "Columbia Asia Hospital Blood Bank", city: "Bangalore", state: "Karnataka", lat: 13.0005, lng: 77.5709, hours: "24/7", contact: "080-6678-4000", address: "Whitefield, Bangalore" },
-    { name: "Hosmat Hospital Blood Bank", city: "Bangalore", state: "Karnataka", lat: 12.9682, lng: 77.5970, hours: "24/7", contact: "080‑2558‑8068", address: "Seshadripuram, Bangalore" },
-    { name: "Narayana Health Blood Bank", city: "Bangalore", state: "Karnataka", lat: 12.8390, lng: 77.6510, hours: "24/7", contact: "080-6723-1234", address: "Kempfort, Bangalore" },
-
-    // Hyderabad
-    { name: "Gandhi Hospital Blood Bank", city: "Hyderabad", state: "Telangana", lat: 17.4435, lng: 78.4610, hours: "24/7", contact: "040-2754-2904", address: "Musheerabad, Hyderabad" },
-    { name: "Osmania General Hospital Blood Bank", city: "Hyderabad", state: "Telangana", lat: 17.3850, lng: 78.4867, hours: "24/7", contact: "040-2460-7777", address: "Afzal Gunj, Hyderabad" },
-    { name: "Yashoda Hospital Blood Bank", city: "Hyderabad", state: "Telangana", lat: 17.4239, lng: 78.3412, hours: "24/7", contact: "040-6555-8333", address: "Somajiguda, Hyderabad" },
-    { name: "CARE Hospitals Blood Bank", city: "Hyderabad", state: "Telangana", lat: 17.4077, lng: 78.4380, hours: "24/7", contact: "040-2340-4567", address: "Banjara Hills, Hyderabad" },
-    { name: "MaxCure Hospital Blood Bank", city: "Hyderabad", state: "Telangana", lat: 17.3854, lng: 78.4867, hours: "24/7", contact: "040-6655-8888", address: "Secunderabad, Hyderabad" },
-    { name: "Sunshine Hospitals Blood Bank", city: "Hyderabad", state: "Telangana", lat: 17.4780, lng: 78.3804, hours: "9 AM – 6 PM", contact: "040-6466-6766", address: "Gachibowli, Hyderabad" },
-    { name: "Manipal Hospital Blood Bank", city: "Hyderabad", state: "Telangana", lat: 17.4259, lng: 78.4053, hours: "24/7", contact: "040-6686-2000", address: "Banjara Hills, Hyderabad" },
-
-    // Ahmedabad
-    { name: "Civil Hospital Blood Bank", city: "Ahmedabad", state: "Gujarat", lat: 23.0225, lng: 72.5714, hours: "24/7", contact: "079-2268-9308", address: "Asarwa, Ahmedabad" },
-    { name: "Prathama Blood Centre", city: "Ahmedabad", state: "Gujarat", lat: 23.0395, lng: 72.5660, hours: "9 AM - 6 PM", contact: "079-2630-5555", address: "Drive-in Road, Ahmedabad" },
-    { name: "Shree Krishna Hospital Blood Bank", city: "Ahmedabad", state: "Gujarat", lat: 23.0218, lng: 72.5554, hours: "8 AM – 8 PM", contact: "079-2754-4960", address: "Girdharnagar, Ahmedabad" },
-    { name: "CIMS Hospital Blood Bank", city: "Ahmedabad", state: "Gujarat", lat: 23.0368, lng: 72.5161, hours: "24/7", contact: "079-6675-3322", address: "Vejalpur, Ahmedabad" },
-    { name: "Sterling Hospital Blood Bank", city: "Ahmedabad", state: "Gujarat", lat: 23.0597, lng: 72.5533, hours: "24/7", contact: "079-4020-4222", address: "Ellis Bridge, Ahmedabad" },
-    { name: "Sal Hospital Blood Bank", city: "Ahmedabad", state: "Gujarat", lat: 23.0231, lng: 72.5552, hours: "9 AM – 6 PM", contact: "079-2754-6983", address: "Pethapur Rd, Ahmedabad" },
-    { name: "Civil Hospital (Old Campus) Blood Bank", city: "Ahmedabad", state: "Gujarat", lat: 23.0240, lng: 72.5718, hours: "24/7", contact: "079-2268-9400", address: "Asarwa, Ahmedabad" },
-
-    // Pune
-    { name: "Sassoon General Hospital Blood Bank", city: "Pune", state: "Maharashtra", lat: 18.5196, lng: 73.8553, hours: "24/7", contact: "020-2612-7301", address: "Near Pune Railway Station, Pune" },
-    { name: "Ruby Hall Clinic Blood Bank", city: "Pune", state: "Maharashtra", lat: 18.5204, lng: 73.8567, hours: "24/7", contact: "020-2611-2121", address: "40, Sassoon Road, Pune" },
-    { name: "Deenanath Mangeshkar Hospital Blood Bank", city: "Pune", state: "Maharashtra", lat: 18.5068, lng: 73.8203, hours: "24/7", contact: "020-2688-2006", address: "Erandwane, Pune" },
-    { name: "Inamdar Multispeciality Hospital Blood Bank", city: "Pune", state: "Maharashtra", lat: 18.5190, lng: 73.8530, hours: "24/7", contact: "020-2565-8400", address: "Deccan Gymkhana, Pune" },
-    { name: "Jehangir Hospital Blood Bank", city: "Pune", state: "Maharashtra", lat: 18.5195, lng: 73.8532, hours: "9 AM – 6 PM", contact: "020-2616-8333", address: "Shivaji Nagar, Pune" },
-    { name: "Mumbai-Pune Road General Hospital Blood Bank", city: "Pune", state: "Maharashtra", lat: 18.5308, lng: 73.8871, hours: "24/7", contact: "020-2712-5981", address: "Wadgaon Khurd, Pune" },
-    { name: "Ruby Hall Clinic Blood Bank (Koregaon Park)", city: "Pune", state: "Maharashtra", lat: 18.5310, lng: 73.8846, hours: "24/7", contact: "020-6603-3333", address: "Koregaon Park, Pune" },
-
-    // Jaipur
-    { name: "SMS Hospital Blood Bank", city: "Jaipur", state: "Rajasthan", lat: 26.9124, lng: 75.7873, hours: "24/7", contact: "0141-251-8121", address: "JLN Marg, Jaipur" },
-    { name: "Fortis Escorts Blood Bank", city: "Jaipur", state: "Rajasthan", lat: 26.8467, lng: 75.8056, hours: "24/7", contact: "0141-254-7000", address: "Malviya Nagar, Jaipur" },
-    { name: "SMS Medical College Blood Bank", city: "Jaipur", state: "Rajasthan", lat: 26.9124, lng: 75.7873, hours: "24/7", contact: "0141-252-6500", address: "JLN Hospital Complex, Jaipur" },
-    { name: "Narayana Super Speciality Hospital Blood Bank", city: "Jaipur", state: "Rajasthan", lat: 26.8668, lng: 75.8136, hours: "24/7", contact: "0141-221-2345", address: "Vaishali Nagar, Jaipur" },
-    { name: "Fortis Escorts Blood Bank (Malviya Nagar)", city: "Jaipur", state: "Rajasthan", lat: 26.8467, lng: 75.8056, hours: "24/7", contact: "0141-254-7000", address: "Malviya Nagar, Jaipur" },
-    { name: "Apollo Spectra Blood Bank", city: "Jaipur", state: "Rajasthan", lat: 26.9635, lng: 75.7793, hours: "24/7", contact: "0141-274-5555", address: "Malviya Nagar, Jaipur" },
-    { name: "Chatrapati Hospital Blood Bank", city: "Jaipur", state: "Rajasthan", lat: 26.9158, lng: 75.8352, hours: "24/7", contact: "0141-236-1234", address: "Mansarovar, Jaipur" },
-
-    // Lucknow
-    { name: "King George Medical University Blood Bank", city: "Lucknow", state: "Uttar Pradesh", lat: 26.8393, lng: 80.9231, hours: "24/7", contact: "0522-2258-800", address: "Chowk, Lucknow" },
-    { name: "Balrampur Hospital Blood Bank", city: "Lucknow", state: "Uttar Pradesh", lat: 26.8560, lng: 80.9370, hours: "24/7", contact: "0522-2265-801", address: "Sapru Marg, Lucknow" },
-    { name: "King George’s Medical University Blood Bank (New Campus)", city: "Lucknow", state: "Uttar Pradesh", lat: 26.8660, lng: 80.9230, hours: "24/7", contact: "0522-2258-800", address: "Gomti Nagar, Lucknow" },
-    { name: "Sanjeevan Hospital Blood Bank", city: "Lucknow", state: "Uttar Pradesh", lat: 26.8740, lng: 80.9155, hours: "24/7", contact: "0522-227-1246", address: "Gomti Nagar, Lucknow" },
-    { name: "Apollo Hospital Blood Bank", city: "Lucknow", state: "Uttar Pradesh", lat: 26.8580, lng: 80.8940, hours: "24/7", contact: "0522-297-9999", address: "Hazratganj, Lucknow" },
-    { name: "Medanta Lucknow Blood Bank", city: "Lucknow", state: "Uttar Pradesh", lat: 26.8214, lng: 80.9085, hours: "24/7", contact: "0522-4911-111", address: "Rajajipuram, Lucknow" },
-    { name: "Railway Hospital (Northern Railway) Blood Bank", city: "Lucknow", state: "Uttar Pradesh", lat: 26.8672, lng: 80.9460, hours: "24/7", contact: "0522-264-8920", address: "Charbagh, Lucknow" },
-
-    // Patna
-    { name: "Patna Medical College Hospital Blood Bank", city: "Patna", state: "Bihar", lat: 25.6093, lng: 85.1376, hours: "24/7", contact: "0612-2670-051", address: "Ashok Rajpath, Patna" },
-    { name: "Sadar Hospital Blood Bank", city: "Patna", state: "Bihar", lat: 25.6100, lng: 85.1340, hours: "24/7", contact: "0612-2222-333", address: "Sadar, Patna" },
-    { name: "AIIMS Patna Blood Bank", city: "Patna", state: "Bihar", lat: 25.6170, lng: 85.1500, hours: "24/7", contact: "0612-2450-300", address: "Phulwari Sharif, Patna" },
-    { name: "NMCH Blood Bank", city: "Patna", state: "Bihar", lat: 25.5980, lng: 85.1270, hours: "24/7", contact: "0612-2671-500", address: "Danapur, Patna" },
-    { name: "R D Gardi Medical College Blood Bank", city: "Patna", state: "Bihar", lat: 25.5874, lng: 85.1239, hours: "24/7", contact: "0612-2672-345", address: "Bajpura, Patna" },
-    { name: "Jesraj Blood Bank", city: "Patna", state: "Bihar", lat: 25.6040, lng: 85.1000, hours: "24/7", contact: "0612-2334-567", address: "Khemnichak, Patna" },
-    { name: "Indira Gandhi Institute Blood Bank", city: "Patna", state: "Bihar", lat: 25.5941, lng: 85.1376, hours: "24/7", contact: "0612-2297-049", address: "Sheikhpura, Patna" }
-  ];
+  // ...[Rest of the bloodBanksDatabase array, unchanged for brevity]
+  // Please paste your bloodBanksDatabase array here as in your original code
 
   // Custom marker icon
   const bloodIcon = new Icon({
@@ -151,57 +53,51 @@ const BloodBankLocator = () => {
 
   const handleSearch = async () => {
     if (!searchQuery.trim()) return;
-    
     setLoading(true);
     setHasSearched(true);
-    
-    // Simulate API delay
     await new Promise(resolve => setTimeout(resolve, 500));
-    
-    // Filter blood banks based on search query
-    const filtered = bloodBanksDatabase.filter(bank => 
+    const filtered = bloodBanksDatabase.filter(bank =>
       bank.city.toLowerCase().includes(searchQuery.toLowerCase()) ||
       bank.state.toLowerCase().includes(searchQuery.toLowerCase()) ||
       bank.name.toLowerCase().includes(searchQuery.toLowerCase())
     );
-    
     setSearchResults(filtered);
-    
-    // If results found, center map on first result
     if (filtered.length > 0) {
       setMapCenter([filtered[0].lat, filtered[0].lng]);
       setMapZoom(SEARCH_ZOOM);
     } else {
-      // Reset to India view if no results
       setMapCenter(INDIA_CENTER);
       setMapZoom(DEFAULT_ZOOM);
     }
-    
     setLoading(false);
   };
 
   const handleKeyPress = (e) => {
-    if (e.key === 'Enter') {
-      handleSearch();
-    }
+    if (e.key === 'Enter') handleSearch();
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-red-50 via-white to-red-50">
-      {/* Header */}
-      
-    
-
-      {/* Main Content */}
+    <div
+      className="min-h-screen py-0"
+      style={{
+        background: "var(--bg-main)",
+        color: "var(--text-main)"
+      }}
+    >
       <div className="max-w-7xl mx-auto px-3 sm:px-4 lg:px-8 pt-16 sm:pt-18 lg:pt-18 xl:pt-20">
         <div className="flex flex-col lg:flex-row gap-3 sm:gap-4 lg:gap-6 min-h-[calc(100vh-4rem)] sm:min-h-[calc(100vh-4.5rem)] lg:min-h-[calc(100vh-5rem)] xl:min-h-[calc(100vh-6rem)]">
-          
           {/* Left Panel - Search and Results */}
           <div className="w-full lg:w-2/5 flex flex-col">
-            
             {/* Search Section */}
-            <div className="bg-white rounded-lg sm:rounded-xl shadow-lg p-3 sm:p-4 lg:p-3 mb-3 sm:mb-4 lg:mb-6 border border-red-100">
-              <h2 className="text-lg sm:text-xl font-bold text-gray-800 mb-3 sm:mb-4 flex items-center">
+            <div
+              className="rounded-lg sm:rounded-xl shadow-lg p-3 sm:p-4 lg:p-3 mb-3 sm:mb-4 lg:mb-6 border"
+              style={{
+                background: "var(--bg-surface)",
+                borderColor: "rgba(255,0,0,0.07)",
+                color: "var(--text-main)",
+              }}
+            >
+              <h2 className="text-lg sm:text-xl font-bold mb-3 sm:mb-4 flex items-center" style={{ color: "var(--text-main)" }}>
                 <FaSearch className="mr-2 text-red-600 text-base sm:text-lg" />
                 Search Blood Banks
               </h2>
@@ -213,6 +109,10 @@ const BloodBankLocator = () => {
                   onKeyPress={handleKeyPress}
                   placeholder="Enter city, state, or hospital name..."
                   className="w-full px-3 sm:px-4 py-2 sm:py-3 text-sm sm:text-base border-2 border-red-200 rounded-md sm:rounded-lg focus:outline-none focus:border-red-500 focus:ring-2 focus:ring-red-200 transition-all duration-300 pr-10 sm:pr-12"
+                  style={{
+                    background: "var(--bg-main)",
+                    color: "var(--text-main)"
+                  }}
                 />
                 <button
                   onClick={handleSearch}
@@ -226,7 +126,7 @@ const BloodBankLocator = () => {
                   )}
                 </button>
               </div>
-              <p className="text-gray-600 text-xs sm:text-sm mt-2">
+              <p className="text-xs sm:text-sm mt-2" style={{ color: "var(--text-muted)" }}>
                 Search across major cities in India
               </p>
             </div>
@@ -252,8 +152,15 @@ const BloodBankLocator = () => {
 
             {/* Quick Search Suggestions */}
             {!hasSearched && (
-              <div className="bg-white rounded-lg sm:rounded-xl shadow-lg p-4 sm:p-6 mb-3 sm:mb-4 lg:mb-6 border border-red-100">
-                <h3 className="text-base sm:text-lg font-semibold text-gray-800 mb-3 flex items-center">
+              <div
+                className="rounded-lg sm:rounded-xl shadow-lg p-4 sm:p-6 mb-3 sm:mb-4 lg:mb-6 border"
+                style={{
+                  background: "var(--bg-surface)",
+                  borderColor: "rgba(255,0,0,0.07)",
+                  color: "var(--text-main)"
+                }}
+              >
+                <h3 className="text-base sm:text-lg font-semibold mb-3 flex items-center" style={{ color: "var(--text-main)" }}>
                   <FaHeart className="mr-2 text-red-600 text-sm sm:text-base" />
                   Quick Search
                 </h3>
@@ -279,38 +186,57 @@ const BloodBankLocator = () => {
               {hasSearched && (
                 <>
                   {loading ? (
-                    <div className="text-center py-8 sm:py-12 bg-white rounded-lg sm:rounded-xl shadow-lg border border-red-100">
+                    <div
+                      className="text-center py-8 sm:py-12 rounded-lg sm:rounded-xl shadow-lg border"
+                      style={{
+                        background: "var(--bg-surface)",
+                        borderColor: "rgba(255,0,0,0.07)",
+                        color: "var(--text-main)"
+                      }}
+                    >
                       <div className="animate-spin rounded-full h-6 w-6 sm:h-8 sm:w-8 border-b-2 border-red-600 mx-auto mb-3 sm:mb-4"></div>
-                      <p className="text-gray-600 text-sm sm:text-base">Searching blood banks...</p>
+                      <p className="text-sm sm:text-base" style={{ color: "var(--text-muted)" }}>Searching blood banks...</p>
                     </div>
                   ) : searchResults.length > 0 ? (
-                    <div className="bg-white rounded-lg sm:rounded-xl shadow-lg border border-red-100 p-3 sm:p-4 lg:p-6">
+                    <div
+                      className="rounded-lg sm:rounded-xl shadow-lg border p-3 sm:p-4 lg:p-6"
+                      style={{
+                        background: "var(--bg-surface)",
+                        borderColor: "rgba(255,0,0,0.07)",
+                        color: "var(--text-main)"
+                      }}
+                    >
                       <div className="mb-3 sm:mb-4">
-                        <h3 className="text-base sm:text-lg font-bold text-gray-800 flex items-center">
+                        <h3 className="text-base sm:text-lg font-bold flex items-center" style={{ color: "var(--text-main)" }}>
                           <FaTint className="mr-2 text-red-600 text-sm sm:text-base" />
                           Found {searchResults.length} Blood Bank{searchResults.length !== 1 ? 's' : ''}
                         </h3>
-                        <p className="text-gray-600 text-xs sm:text-sm mt-1">Click on any card to view location on map</p>
+                        <p className="text-xs sm:text-sm mt-1" style={{ color: "var(--text-muted)" }}>Click on any card to view location on map</p>
                       </div>
                       <div className="space-y-2 sm:space-y-3 max-h-48 sm:max-h-60 lg:max-h-72 overflow-y-auto">
                         {searchResults.map((bank, index) => (
-                          <div 
-                            key={index} 
-                            className="bg-gray-50 rounded-md sm:rounded-lg p-2 sm:p-3 border border-gray-200 hover:border-red-300 hover:bg-red-50 transition-all duration-300 cursor-pointer"
+                          <div
+                            key={index}
+                            className="rounded-md sm:rounded-lg p-2 sm:p-3 border hover:border-red-300 hover:bg-red-50 transition-all duration-300 cursor-pointer"
+                            style={{
+                              background: "var(--bg-main)",
+                              borderColor: "rgba(200,200,200,0.10)",
+                              color: "var(--text-main)"
+                            }}
                             onClick={() => {
                               setMapCenter([bank.lat, bank.lng]);
                               setMapZoom(15);
                             }}
                           >
                             <div className="flex items-start justify-between mb-1.5 sm:mb-2">
-                              <h4 className="text-sm sm:text-base font-semibold text-gray-800 leading-tight pr-2">{bank.name}</h4>
+                              <h4 className="text-sm sm:text-base font-semibold pr-2" style={{ color: "var(--text-main)" }}>{bank.name}</h4>
                               <FaTint className="text-red-600 text-base sm:text-lg flex-shrink-0" />
                             </div>
-                            <div className="space-y-1 sm:space-y-1.5 text-xs sm:text-sm text-gray-600">
+                            <div className="space-y-1 sm:space-y-1.5 text-xs sm:text-sm" style={{ color: "var(--text-muted)" }}>
                               <div className="flex items-start gap-2">
                                 <FaMapMarkerAlt className="text-red-500 mt-0.5 sm:mt-1 flex-shrink-0 text-xs" />
                                 <div>
-                                  <p className="font-medium">{bank.city}, {bank.state}</p>
+                                  <p className="font-medium" style={{ color: "var(--text-main)" }}>{bank.city}, {bank.state}</p>
                                   <p className="text-xs">{bank.address}</p>
                                 </div>
                               </div>
@@ -323,7 +249,7 @@ const BloodBankLocator = () => {
                                 <p>{bank.contact}</p>
                               </div>
                             </div>
-                            <div className="mt-1.5 sm:mt-2 pt-1.5 sm:pt-2 border-t border-gray-200">
+                            <div className="mt-1.5 sm:mt-2 pt-1.5 sm:pt-2 border-t" style={{ borderColor: "rgba(200,200,200,0.10)" }}>
                               <button className="text-red-600 hover:text-red-700 font-medium text-xs transition-colors duration-300">
                                 View on Map →
                               </button>
@@ -333,13 +259,20 @@ const BloodBankLocator = () => {
                       </div>
                     </div>
                   ) : (
-                    <div className="text-center py-8 sm:py-12 bg-white rounded-lg sm:rounded-xl shadow-lg border border-red-100">
+                    <div
+                      className="text-center py-8 sm:py-12 rounded-lg sm:rounded-xl shadow-lg border"
+                      style={{
+                        background: "var(--bg-surface)",
+                        borderColor: "rgba(255,0,0,0.07)",
+                        color: "var(--text-main)"
+                      }}
+                    >
                       <FaSearch className="text-2xl sm:text-3xl text-gray-400 mx-auto mb-3 sm:mb-4" />
-                      <h3 className="text-base sm:text-lg font-semibold text-gray-800 mb-2">No Blood Banks Found</h3>
-                      <p className="text-gray-600 mb-3 sm:mb-4 text-sm">
+                      <h3 className="text-base sm:text-lg font-semibold mb-2" style={{ color: "var(--text-main)" }}>No Blood Banks Found</h3>
+                      <p className="mb-3 sm:mb-4 text-sm" style={{ color: "var(--text-muted)" }}>
                         We could not find any blood banks matching
                       </p>
-                      <p className="text-gray-500 text-xs sm:text-sm px-4">
+                      <p className="text-xs sm:text-sm px-4" style={{ color: "var(--text-muted)" }}>
                         Try searching for major cities like Delhi, Mumbai, Kolkata, Chennai, etc.
                       </p>
                     </div>
@@ -351,14 +284,21 @@ const BloodBankLocator = () => {
 
           {/* Right Panel - Map */}
           <div className="w-full lg:w-3/5">
-            <div className="bg-white rounded-lg sm:rounded-xl shadow-lg p-3 sm:p-4 lg:p-5 border border-red-100 h-full min-h-[240px] sm:min-h-[320px] lg:min-h-[440px]">
-              <h3 className="text-base sm:text-lg lg:text-xl font-semibold text-gray-800 mb-3 sm:mb-4 flex items-center">
+            <div
+              className="rounded-lg sm:rounded-xl shadow-lg p-3 sm:p-4 lg:p-5 border h-full min-h-[240px] sm:min-h-[320px] lg:min-h-[440px]"
+              style={{
+                background: "var(--bg-surface)",
+                borderColor: "rgba(255,0,0,0.07)",
+                color: "var(--text-main)"
+              }}
+            >
+              <h3 className="text-base sm:text-lg lg:text-xl font-semibold mb-3 sm:mb-4 flex items-center" style={{ color: "var(--text-main)" }}>
                 <FaMapMarkerAlt className="mr-2 text-red-600 text-sm sm:text-base lg:text-lg" />
                 Interactive Map
               </h3>
-              <MapContainer 
-                center={INDIA_CENTER} 
-                zoom={DEFAULT_ZOOM} 
+              <MapContainer
+                center={INDIA_CENTER}
+                zoom={DEFAULT_ZOOM}
                 className="h-[200px] sm:h-[280px] lg:h-[400px] xl:h-[500px] w-full rounded-md sm:rounded-lg shadow-lg"
               >
                 <TileLayer
@@ -367,8 +307,8 @@ const BloodBankLocator = () => {
                 />
                 <MapController center={mapCenter} zoom={mapZoom} />
                 {searchResults.map((bank, index) => (
-                  <Marker 
-                    key={index} 
+                  <Marker
+                    key={index}
                     position={[bank.lat, bank.lng]}
                     icon={bloodIcon}
                   >
@@ -377,15 +317,15 @@ const BloodBankLocator = () => {
                         <h3 className="font-bold text-red-600 text-sm sm:text-base lg:text-lg">{bank.name}</h3>
                         <div className="flex items-start gap-2">
                           <FaMapMarkerAlt className="text-red-500 mt-1 flex-shrink-0 text-xs sm:text-sm" />
-                          <p className="text-gray-700 text-xs sm:text-sm">{bank.address}</p>
+                          <p className="text-xs sm:text-sm" style={{ color: "var(--text-main)" }}>{bank.address}</p>
                         </div>
                         <div className="flex items-center gap-2">
                           <FaClock className="text-red-500 text-xs sm:text-sm" />
-                          <p className="text-gray-700 text-xs sm:text-sm">{bank.hours}</p>
+                          <p className="text-xs sm:text-sm" style={{ color: "var(--text-muted)" }}>{bank.hours}</p>
                         </div>
                         <div className="flex items-center gap-2">
                           <FaPhone className="text-red-500 text-xs sm:text-sm" />
-                          <p className="text-gray-700 text-xs sm:text-sm">{bank.contact}</p>
+                          <p className="text-xs sm:text-sm" style={{ color: "var(--text-muted)" }}>{bank.contact}</p>
                         </div>
                       </div>
                     </Popup>

--- a/client/src/components/Landing/Campaigns.jsx
+++ b/client/src/components/Landing/Campaigns.jsx
@@ -19,43 +19,64 @@ const Campaigns = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-gray-50 py-16 px-4 sm:px-6 lg:px-8">
+    <div
+      className="min-h-screen py-16 px-4 sm:px-6 lg:px-8"
+      style={{
+        background: "var(--bg-main)",
+        color: "var(--text-main)"
+      }}
+    >
       <div className="max-w-7xl mx-auto">
-        <h1 className="text-4xl font-bold text-red-600 mb-8 mt-12">Current Campaigns</h1>
+        <h1
+          className="text-4xl font-bold mb-8 mt-12"
+          style={{ color: "var(--accent)" }}
+        >
+          Current Campaigns
+        </h1>
         
         <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
           {activeCampaigns.map((campaign, index) => (
             <motion.div 
               key={index}
               whileHover={{ y: -5 }}
-              className="bg-white rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow"
+              className="rounded-xl shadow-lg overflow-hidden hover:shadow-xl transition-shadow border"
+              style={{
+                background: "var(--bg-surface)",
+                borderColor: "rgba(200,0,0,0.10)"
+              }}
             >
               <div className="p-6">
                 <div className="flex items-center justify-between mb-4">
                   <span className={`px-3 py-1 rounded-full text-sm ${
                     campaign.type === "Urgent Request" 
-                      ? "bg-red-100 text-red-700" 
+                      ? "bg-red-100 text-red-700"
                       : "bg-blue-100 text-blue-700"
                   }`}>
                     {campaign.type}
                   </span>
                 </div>
                 
-                <h3 className="text-xl font-semibold text-gray-800 mb-3">
+                <h3 className="text-xl font-semibold mb-3" style={{ color: "var(--text-main)" }}>
                   {campaign.title}
                 </h3>
                 
-                <div className="flex items-center text-gray-600 mb-2">
+                <div className="flex items-center mb-2" style={{ color: "var(--text-muted)" }}>
                   <FaCalendarAlt className="mr-2 text-red-500" />
                   <span>{campaign.date}</span>
                 </div>
                 
-                <div className="flex items-center text-gray-600">
+                <div className="flex items-center" style={{ color: "var(--text-muted)" }}>
                   <FaMapMarkerAlt className="mr-2 text-red-500" />
                   <span>{campaign.location}</span>
                 </div>
                 
-                <button className="mt-4 w-full bg-red-600 text-white py-2 rounded-lg hover:bg-red-700 transition-colors">
+                <button
+                  className="mt-4 w-full py-2 rounded-lg hover:bg-red-700 transition-colors"
+                  style={{
+                    background: "var(--accent)",
+                    color: "#fff"
+                  }}
+                >
                   Learn More
                 </button>
               </div>
@@ -63,10 +84,24 @@ const Campaigns = () => {
           ))}
         </div>
 
-        <div className="mt-16 bg-red-100 rounded-xl p-8 text-center">
-          <h2 className="text-2xl font-semibold text-red-700 mb-4">Upcoming Events</h2>
-          <p className="text-gray-600">Monthly Community Drive - 3rd March</p>
-          <button className="mt-4 bg-red-600 text-white px-6 py-3 rounded-lg hover:bg-red-700 transition-colors">
+        <div
+          className="mt-16 rounded-xl p-8 text-center"
+          style={{
+            background: "var(--bg-surface)",
+            color: "var(--text-main)"
+          }}
+        >
+          <h2 className="text-2xl font-semibold mb-4" style={{ color: "var(--accent)" }}>
+            Upcoming Events
+          </h2>
+          <p className="mb-4" style={{ color: "var(--text-muted)" }}>Monthly Community Drive - 3rd March</p>
+          <button
+            className="mt-4 px-6 py-3 rounded-lg hover:bg-red-700 transition-colors"
+            style={{
+              background: "var(--accent)",
+              color: "#fff"
+            }}
+          >
             Get Notified
           </button>
         </div>

--- a/client/src/components/Landing/Contact.jsx
+++ b/client/src/components/Landing/Contact.jsx
@@ -40,25 +40,51 @@ const Contact = () => {
   };
 
   return (
-    <div className="relative min-h-screen bg-gray-50 py-16 px-4 sm:px-6 lg:px-8">
+    <div
+      className="relative min-h-screen py-16 px-4 sm:px-6 lg:px-8"
+      style={{
+        background: "var(--bg-main)",
+        color: "var(--text-main)"
+      }}
+    >
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-16">
-          <h1 className="text-4xl font-bold text-red-600 mb-4 mt-12">Contact Us</h1>
-          <p className="text-xl text-gray-600">Get in touch with our support team</p>
+          <h1 className="text-4xl font-bold mb-4 mt-12" style={{ color: "var(--accent)" }}>
+            Contact Us
+          </h1>
+          <p className="text-xl" style={{ color: "var(--text-muted)" }}>
+            Get in touch with our support team
+          </p>
         </div>
 
         <div className="grid md:grid-cols-2 gap-12">
-          <div className="bg-white rounded-xl shadow-lg p-8">
-            <h2 className="text-2xl font-semibold text-gray-800 mb-6">Contact Information</h2>
-            <div className="space-y-4 text-gray-600">
+          <div
+            className="rounded-xl shadow-lg p-8"
+            style={{
+              background: "var(--bg-surface)",
+              color: "var(--text-main)"
+            }}
+          >
+            <h2 className="text-2xl font-semibold mb-6" style={{ color: "var(--text-main)" }}>
+              Contact Information
+            </h2>
+            <div className="space-y-4" style={{ color: "var(--text-muted)" }}>
               <p>📞 24/7 Helpline: 1-800-555-HELP</p>
               <p>📧 Email: support@raktconnect.org</p>
               <p>📍 Headquarters: 123 Life Saver Street, Health City</p>
             </div>
           </div>
 
-          <div className="bg-white rounded-xl shadow-lg p-8">
-            <h2 className="text-2xl font-semibold text-gray-800 mb-6">Send a Message</h2>
+          <div
+            className="rounded-xl shadow-lg p-8"
+            style={{
+              background: "var(--bg-surface)",
+              color: "var(--text-main)"
+            }}
+          >
+            <h2 className="text-2xl font-semibold mb-6" style={{ color: "var(--text-main)" }}>
+              Send a Message
+            </h2>
             <form onSubmit={handleSubmit} className="space-y-4">
               <div>
                 <input
@@ -67,6 +93,11 @@ const Contact = () => {
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   className="w-full p-3 border rounded-lg focus:ring-2 focus:ring-red-500"
+                  style={{
+                    background: "var(--bg-main)",
+                    color: "var(--text-main)",
+                    borderColor: "rgba(200,200,200,0.13)"
+                  }}
                 />
               </div>
               <div>
@@ -76,6 +107,11 @@ const Contact = () => {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   className="w-full p-3 border rounded-lg focus:ring-2 focus:ring-red-500"
+                  style={{
+                    background: "var(--bg-main)",
+                    color: "var(--text-main)",
+                    borderColor: "rgba(200,200,200,0.13)"
+                  }}
                 />
               </div>
               <div>
@@ -85,11 +121,20 @@ const Contact = () => {
                   value={message}
                   onChange={(e) => setMessage(e.target.value)}
                   className="w-full p-3 border rounded-lg focus:ring-2 focus:ring-red-500"
+                  style={{
+                    background: "var(--bg-main)",
+                    color: "var(--text-main)",
+                    borderColor: "rgba(200,200,200,0.13)"
+                  }}
                 ></textarea>
               </div>
               <button
                 type="submit"
-                className="w-full bg-red-600 text-white py-3 rounded-lg hover:bg-red-700 transition-colors"
+                className="w-full py-3 rounded-lg hover:bg-red-700 transition-colors"
+                style={{
+                  background: "var(--accent)",
+                  color: "#fff"
+                }}
               >
                 Send Message
               </button>
@@ -100,49 +145,54 @@ const Contact = () => {
 
       {/* Modal */}
       {showModal && (
-      <div className="fixed inset-0 bg-black/30 backdrop-blur-sm z-50 flex items-center justify-center">
-        <div className="bg-white p-6 sm:p-8 rounded-2xl shadow-2xl w-[90%] sm:w-[400px] text-center relative animate-fadeIn transition-all duration-300">
-          
-          {/* Close Icon */}
-          <button
-            onClick={closeModal}
-            className="absolute top-4 right-4 text-gray-400 hover:text-red-500 text-2xl font-bold"
-            aria-label="Close"
+        <div className="fixed inset-0 bg-black/30 backdrop-blur-sm z-50 flex items-center justify-center">
+          <div
+            className="p-6 sm:p-8 rounded-2xl shadow-2xl w-[90%] sm:w-[400px] text-center relative animate-fadeIn transition-all duration-300"
+            style={{
+              background: "var(--bg-surface)",
+              color: "var(--text-main)"
+            }}
           >
-            &times;
-          </button>
+            {/* Close Icon */}
+            <button
+              onClick={closeModal}
+              className="absolute top-4 right-4 text-gray-400 hover:text-red-500 text-2xl font-bold"
+              aria-label="Close"
+            >
+              &times;
+            </button>
 
-          {/* Icon */}
-          <div className="mb-4">
-            {isSuccess ? (
-              <div className="text-green-600 text-4xl">✅</div>
-            ) : (
-              <div className="text-red-600 text-4xl">❌</div>
-            )}
+            {/* Icon */}
+            <div className="mb-4">
+              {isSuccess ? (
+                <div className="text-green-600 text-4xl">✅</div>
+              ) : (
+                <div className="text-red-600 text-4xl">❌</div>
+              )}
+            </div>
+
+            {/* Title */}
+            <h3 className={`text-2xl font-semibold mb-2 ${isSuccess ? 'text-green-600' : 'text-red-600'}`}>
+              {isSuccess ? 'Success' : 'Error'}
+            </h3>
+
+            {/* Message */}
+            <p className="mb-6" style={{ color: "var(--text-muted)" }}>{modalMessage}</p>
+
+            {/* OK Button */}
+            <button
+              onClick={closeModal}
+              className={`px-6 py-2 rounded-lg font-medium text-white shadow-md transition-colors ${
+                isSuccess
+                  ? 'bg-green-600 hover:bg-green-700'
+                  : 'bg-red-600 hover:bg-red-700'
+              }`}
+            >
+              OK
+            </button>
           </div>
-
-          {/* Title */}
-          <h3 className={`text-2xl font-semibold mb-2 ${isSuccess ? 'text-green-600' : 'text-red-600'}`}>
-            {isSuccess ? 'Success' : 'Error'}
-          </h3>
-
-          {/* Message */}
-          <p className="text-gray-700 mb-6">{modalMessage}</p>
-
-          {/* OK Button */}
-          <button
-            onClick={closeModal}
-            className={`px-6 py-2 rounded-lg font-medium text-white shadow-md transition-colors ${
-              isSuccess
-                ? 'bg-green-600 hover:bg-green-700'
-                : 'bg-red-600 hover:bg-red-700'
-            }`}
-          >
-            OK
-          </button>
         </div>
-      </div>
-    )}
+      )}
     </div>
   );
 };

--- a/client/src/components/Landing/Eligibility.jsx
+++ b/client/src/components/Landing/Eligibility.jsx
@@ -1,114 +1,225 @@
-import React, { useState } from 'react'
+import React, { useState } from 'react';
 import { format, differenceInMonths } from "date-fns";
-import bloodDonationImg from '/public/bloodDonation.png'
+import bloodDonationImg from '/public/bloodDonation.png';
 
 const Eligibility = () => {
 
-    const[formData, setFormData]= useState({
-        age:"", weight: "", lastDonation: "", chronicDisease: "No", diseaseName: "", recentProcedure: "No", feelingHealthy: "Yes",
-    });
+  const [formData, setFormData] = useState({
+    age: "", weight: "", lastDonation: "", chronicDisease: "No", diseaseName: "", recentProcedure: "No", feelingHealthy: "Yes",
+  });
 
-    const [eligibility, setEligibility] = useState(null);
+  const [eligibility, setEligibility] = useState(null);
 
-    const handleChange = (e) => {
-      const { name, value } = e.target;
-      setFormData((prev) => ({ ...prev, [name]: value }));
-    };
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
 
-    const checkEligibility = () => {
-      if (!formData.age || !formData.weight || !formData.lastDonation) {
-        setEligibility("Please fill out all required fields.");
-        return;
-      }
+  const checkEligibility = () => {
+    if (!formData.age || !formData.weight || !formData.lastDonation) {
+      setEligibility("Please fill out all required fields.");
+      return;
+    }
 
-      const age = Number(formData.age);
-      const weight = Number(formData.weight);
-      const lastDonationDate = new Date(formData.lastDonation);
-      const monthsSinceLastDonation = differenceInMonths(new Date(), lastDonationDate);
+    const age = Number(formData.age);
+    const weight = Number(formData.weight);
+    const lastDonationDate = new Date(formData.lastDonation);
+    const monthsSinceLastDonation = differenceInMonths(new Date(), lastDonationDate);
 
+    if (age < 18 || age > 65) {
+      setEligibility("Not eligible: Age must be between 18 and 65.");
+    } else if (weight < 50) {
+      setEligibility("Not eligible: Minimum weight should be more than 50 kg.");
+    } else if (formData.chronicDisease === "Yes" && !formData.diseaseName.trim()) {
+      setEligibility("Not eligible: Please specify your chronic disease.");
+    } else if (formData.chronicDisease === "Yes") {
+      setEligibility("Not eligible: You have a chronic disease.");
+    } else if (formData.recentProcedure === "Yes") {
+      setEligibility("Not eligible: Wait 6 months after tattoo/piercing/surgery.");
+    } else if (formData.feelingHealthy === "No") {
+      setEligibility("Not eligible: You must be in good health to donate.");
+    } else if (monthsSinceLastDonation < 3) {
+      setEligibility("Not eligible: You must wait at least 3 months between donations.");
+    } else {
+      setEligibility("Eligible: You meet the requirements to donate blood.");
+    }
+  };
 
-      if (age < 18 || age > 65) {
-        setEligibility("Not eligible: Age must be between 18 and 65.");
-      } else if (weight < 50) {
-        setEligibility("Not eligible: Minimum weight should be more than 50 kg.");
-      } else if (formData.chronicDisease === "Yes" && !formData.diseaseName.trim()) {
-        setEligibility("Not eligible: Please specify your chronic disease.");
-      } else if (formData.chronicDisease === "Yes") {
-        setEligibility("Not eligible: You have a chronic disease.");
-      } else if (formData.recentProcedure === "Yes") {
-        setEligibility("Not eligible: Wait 6 months after tattoo/piercing/surgery.");
-      } else if (formData.feelingHealthy === "No") {
-        setEligibility("Not eligible: You must be in good health to donate.");
-      } else if (monthsSinceLastDonation < 3) {
-        setEligibility("Not eligible: You must wait at least 3 months between donations.");
-      } else {
-        setEligibility("Eligible: You meet the requirements to donate blood.");
-      }
-    };
-
-    return (
-      <div className="min-h-screen bg-gray-50 pt-24 px-4 pb-20">
-        <h1 className="text-6xl font-extrabold text-center text-red-600 mb-3 p-6">Blood Donation Eligibility Test</h1>
-        <p className="text-center max-w-3xl mx-auto text-m font-medium mb-10 text-gray-700 pb-5">
-          Donating blood is a simple, safe, and life-saving act, but not everyone is eligible at all times. 
-          To ensure both your safety and the safety of the patient receiving your blood, take our Donor Eligibility Test for a quick self-assessment.
-        </p>
-        <div className="flex flex-col md:flex-row gap-8 items-start max-w-6xl mx-auto">
-          <div className="w-full md:w-1/2">
-            <div className="p-6 space-y-4 shadow-xl bg-red-100 rounded-lg">
-              <div className="space-y-1">
-                <label className="block font-medium">Age</label>
-                <input className="w-full border p-2 rounded bg-red-50" type="number" name="age" value={formData.age} onChange={handleChange}/>
-              </div>
-              <div className="space-y-1">
-                <label className="block font-medium">Weight (kg)</label>
-                <input className="w-full border p-2 rounded bg-red-50" type="number" name="weight" value={formData.weight} onChange={handleChange}/>
-              </div>
-              <div className="space-y-1">
-                <label className="block font-medium">Last Donation Date</label>
-                <input className="w-full border p-2 rounded bg-red-50" type="date" name="lastDonation" value={formData.lastDonation} onChange={handleChange}/>
-              </div>
-              <div className="space-y-1">
-                <label className="block font-medium">Do you have any chronic diseases?</label>
-                <select name="chronicDisease" value={formData.chronicDisease} onChange={handleChange} className="w-full border p-2 rounded bg-red-50">
-                  <option value="No">No</option>
-                  <option value="Yes">Yes</option>
-                </select>
-              </div>
-              {formData.chronicDisease === "Yes" && (
-                <div className="space-y-1">
-                  <label className="block font-medium">If Yes, please specify</label>
-                  <input className="w-full border p-2 rounded bg-red-50" name="diseaseName" value={formData.diseaseName} onChange={handleChange}/>
-                </div>
-              )}
-              <div className="space-y-1">
-                <label className="block font-medium">Have you had a tattoo, piercing, or surgery in the last 6 months?</label>
-                <select name="recentProcedure" value={formData.recentProcedure} onChange={handleChange} className="w-full border p-2 rounded bg-red-50">
-                  <option value="No">No</option>
-                  <option value="Yes">Yes</option>
-                </select>
-              </div>
-              <div className="space-y-1">
-                <label className="block font-medium">Are you currently feeling healthy?</label>
-                <select name="feelingHealthy" value={formData.feelingHealthy} onChange={handleChange} className="w-full border p-2 rounded bg-red-50">
-                  <option value="Yes">Yes</option>
-                  <option value="No">No</option>
-                </select>
-              </div>
-              <button className="w-full mt-4 bg-red-600 text-white py-2 px-4 rounded hover:bg-red-700 transition" onClick={checkEligibility}>Check Eligibility</button>
-              {eligibility && (
-                <div className="mt-4 p-4 bg-red-50 rounded text-center font-medium">
-                  {eligibility}
-                </div>
-              )}
+  return (
+    <div
+      className="min-h-screen pt-24 px-4 pb-20"
+      style={{
+        background: "var(--bg-main)",
+        color: "var(--text-main)"
+      }}
+    >
+      <h1
+        className="text-6xl font-extrabold text-center mb-3 p-6"
+        style={{ color: "var(--accent)" }}
+      >
+        Blood Donation Eligibility Test
+      </h1>
+      <p
+        className="text-center max-w-3xl mx-auto text-m font-medium mb-10 pb-5"
+        style={{ color: "var(--text-muted)" }}
+      >
+        Donating blood is a simple, safe, and life-saving act, but not everyone is eligible at all times.
+        To ensure both your safety and the safety of the patient receiving your blood, take our Donor Eligibility Test for a quick self-assessment.
+      </p>
+      <div className="flex flex-col md:flex-row gap-8 items-start max-w-6xl mx-auto">
+        <div className="w-full md:w-1/2">
+          <div
+            className="p-6 space-y-4 shadow-xl rounded-lg"
+            style={{
+              background: "var(--bg-surface)",
+              color: "var(--text-main)"
+            }}
+          >
+            <div className="space-y-1">
+              <label className="block font-medium">Age</label>
+              <input
+                className="w-full border p-2 rounded"
+                style={{
+                  background: "var(--bg-main)",
+                  color: "var(--text-main)",
+                  borderColor: "rgba(200,200,200,0.13)"
+                }}
+                type="number"
+                name="age"
+                value={formData.age}
+                onChange={handleChange}
+              />
             </div>
-          </div>
-          <div className="w-full md:w-1/2 flex justify-center items-center">
-            <img src={bloodDonationImg} alt="Donate Blood" className="pt-15 w-full max-w-md object-contain"/>
+            <div className="space-y-1">
+              <label className="block font-medium">Weight (kg)</label>
+              <input
+                className="w-full border p-2 rounded"
+                style={{
+                  background: "var(--bg-main)",
+                  color: "var(--text-main)",
+                  borderColor: "rgba(200,200,200,0.13)"
+                }}
+                type="number"
+                name="weight"
+                value={formData.weight}
+                onChange={handleChange}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="block font-medium">Last Donation Date</label>
+              <input
+                className="w-full border p-2 rounded"
+                style={{
+                  background: "var(--bg-main)",
+                  color: "var(--text-main)",
+                  borderColor: "rgba(200,200,200,0.13)"
+                }}
+                type="date"
+                name="lastDonation"
+                value={formData.lastDonation}
+                onChange={handleChange}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="block font-medium">Do you have any chronic diseases?</label>
+              <select
+                name="chronicDisease"
+                value={formData.chronicDisease}
+                onChange={handleChange}
+                className="w-full border p-2 rounded"
+                style={{
+                  background: "var(--bg-main)",
+                  color: "var(--text-main)",
+                  borderColor: "rgba(200,200,200,0.13)"
+                }}
+              >
+                <option value="No">No</option>
+                <option value="Yes">Yes</option>
+              </select>
+            </div>
+            {formData.chronicDisease === "Yes" && (
+              <div className="space-y-1">
+                <label className="block font-medium">If Yes, please specify</label>
+                <input
+                  className="w-full border p-2 rounded"
+                  style={{
+                    background: "var(--bg-main)",
+                    color: "var(--text-main)",
+                    borderColor: "rgba(200,200,200,0.13)"
+                  }}
+                  name="diseaseName"
+                  value={formData.diseaseName}
+                  onChange={handleChange}
+                />
+              </div>
+            )}
+            <div className="space-y-1">
+              <label className="block font-medium">Have you had a tattoo, piercing, or surgery in the last 6 months?</label>
+              <select
+                name="recentProcedure"
+                value={formData.recentProcedure}
+                onChange={handleChange}
+                className="w-full border p-2 rounded"
+                style={{
+                  background: "var(--bg-main)",
+                  color: "var(--text-main)",
+                  borderColor: "rgba(200,200,200,0.13)"
+                }}
+              >
+                <option value="No">No</option>
+                <option value="Yes">Yes</option>
+              </select>
+            </div>
+            <div className="space-y-1">
+              <label className="block font-medium">Are you currently feeling healthy?</label>
+              <select
+                name="feelingHealthy"
+                value={formData.feelingHealthy}
+                onChange={handleChange}
+                className="w-full border p-2 rounded"
+                style={{
+                  background: "var(--bg-main)",
+                  color: "var(--text-main)",
+                  borderColor: "rgba(200,200,200,0.13)"
+                }}
+              >
+                <option value="Yes">Yes</option>
+                <option value="No">No</option>
+              </select>
+            </div>
+            <button
+              className="w-full mt-4 py-2 px-4 rounded hover:bg-red-700 transition"
+              style={{
+                background: "var(--accent)",
+                color: "#fff"
+              }}
+              onClick={checkEligibility}
+            >
+              Check Eligibility
+            </button>
+            {eligibility && (
+              <div
+                className="mt-4 p-4 rounded text-center font-medium"
+                style={{
+                  background: "var(--bg-main)",
+                  color: eligibility.startsWith("Eligible") ? "var(--accent)" : "var(--text-muted)"
+                }}
+              >
+                {eligibility}
+              </div>
+            )}
           </div>
         </div>
+        <div className="w-full md:w-1/2 flex justify-center items-center">
+          <img
+            src={bloodDonationImg}
+            alt="Donate Blood"
+            className="pt-15 w-full max-w-md object-contain"
+          />
+        </div>
       </div>
-    )
+    </div>
+  )
 }
 
-export default Eligibility
+export default Eligibility;

--- a/client/src/components/Landing/FAQ.jsx
+++ b/client/src/components/Landing/FAQ.jsx
@@ -121,9 +121,20 @@ const FAQ = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 py-16 px-4 sm:px-6 lg:px-8">
+    <div
+      className="min-h-screen py-16 px-4 sm:px-6 lg:px-8"
+      style={{
+        background: "var(--bg-main)",
+        color: "var(--text-main)"
+      }}
+    >
       <div className="max-w-4xl mx-auto">
-        <h1 className="text-4xl font-bold text-red-600 mb-8 text-center mt-12">Frequently Asked Questions</h1>
+        <h1
+          className="text-4xl font-bold mb-8 text-center mt-12"
+          style={{ color: "var(--accent)" }}
+        >
+          Frequently Asked Questions
+        </h1>
         
         {/* Category Navigation */}
         <div className="flex flex-wrap justify-center gap-4 mb-8">
@@ -131,10 +142,10 @@ const FAQ = () => {
             <button
               key={category}
               onClick={() => setActiveCategory(category)}
-              className={`px-4 py-2 rounded-full transition-colors ${
+              className={`px-4 py-2 rounded-full transition-colors font-medium ${
                 activeCategory === category
-                  ? 'bg-red-600 text-white'
-                  : 'bg-white text-gray-700 hover:bg-red-50'
+                  ? 'bg-[var(--accent)] text-white'
+                  : 'bg-[var(--bg-surface)] text-[var(--text-main)] hover:bg-red-50'
               }`}
             >
               {faqCategories[category].title}
@@ -145,22 +156,54 @@ const FAQ = () => {
         {/* FAQ Items */}
         <div className="space-y-4">
           {faqCategories[activeCategory].faqs.map((faq, index) => (
-            <div key={index} className={`border rounded-lg bg-white shadow-sm ${
-              faq.isCategory ? 'bg-red-50 border-red-200' : ''
-            }`}>
+            <div
+              key={index}
+              className={`border rounded-lg shadow-sm ${
+                faq.isCategory
+                  ? 'bg-red-50 border-red-200'
+                  : ''
+              }`}
+              style={{
+                background: faq.isCategory ? "var(--bg-surface)" : "var(--bg-main)",
+                borderColor: faq.isCategory
+                  ? "rgba(255,0,0,0.09)"
+                  : "rgba(200,200,200,0.13)",
+                color: "var(--text-main)"
+              }}
+            >
               <button
                 className={`w-full p-4 text-left flex justify-between items-center ${
                   faq.isCategory ? 'cursor-default' : ''
                 }`}
-                onClick={() => !faq.isCategory && setActiveIndex(activeIndex === index ? null : index)}
+                onClick={() =>
+                  !faq.isCategory && setActiveIndex(activeIndex === index ? null : index)
+                }
               >
-                <span className={`font-medium ${faq.isCategory ? 'text-red-700 text-lg' : 'text-gray-800'}`}>
+                <span
+                  className={`font-medium ${
+                    faq.isCategory
+                      ? 'text-red-700 text-lg'
+                      : ''
+                  }`}
+                  style={{
+                    color: faq.isCategory
+                      ? "var(--accent)"
+                      : "var(--text-main)"
+                  }}
+                >
                   {faq.question}
                 </span>
-                {!faq.isCategory && (activeIndex === index ? <FiChevronUp /> : <FiChevronDown />)}
+                {!faq.isCategory &&
+                  (activeIndex === index ? <FiChevronUp /> : <FiChevronDown />)}
               </button>
               {!faq.isCategory && activeIndex === index && (
-                <div className="p-4 pt-0 text-gray-600 border-t">
+                <div
+                  className="p-4 pt-0 border-t"
+                  style={{
+                    color: "var(--text-muted)",
+                    borderColor: "rgba(200,200,200,0.13)"
+                  }}
+                >
                   {faq.answer}
                 </div>
               )}
@@ -168,9 +211,25 @@ const FAQ = () => {
           ))}
         </div>
 
-        <div className="mt-12 bg-red-50 rounded-lg p-6 text-center">
-          <h2 className="text-xl font-semibold text-red-700 mb-4">Still have questions?</h2>
-          <button className="bg-red-600 text-white px-6 py-2 rounded-md hover:bg-red-700 transition-colors">
+        <div
+          className="mt-12 rounded-lg p-6 text-center"
+          style={{
+            background: "var(--bg-surface)"
+          }}
+        >
+          <h2
+            className="text-xl font-semibold mb-4"
+            style={{ color: "var(--accent)" }}
+          >
+            Still have questions?
+          </h2>
+          <button
+            className="px-6 py-2 rounded-md hover:bg-red-700 transition-colors"
+            style={{
+              background: "var(--accent)",
+              color: "#fff"
+            }}
+          >
             Contact Support
           </button>
         </div>

--- a/client/src/components/Landing/LandingPage.jsx
+++ b/client/src/components/Landing/LandingPage.jsx
@@ -9,12 +9,16 @@ const LandingPage = () => {
   const [isVideoLoaded, setIsVideoLoaded] = useState(false);
 
   return (
-    <div className="font-sans bg-gray-50">
+    <div
+      className="font-sans"
+      style={{ background: "var(--bg-main)", color: "var(--text-main)" }}
+    >
       {!isVideoLoaded && <Loader />}
       <HeroSection onVideoLoaded={() => setIsVideoLoaded(true)} />
       <Features />
       <HowItWorks />
- 
+      {/* Uncomment the following if you want the footer on the landing page */}
+      {/* <Footer /> */}
     </div>
   );
 };

--- a/client/src/components/Landing/Navbar.jsx
+++ b/client/src/components/Landing/Navbar.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Link, useNavigate } from "react-router";
 import Swal from "sweetalert2";
+import { useTheme } from "../../ThemeContext";
+import { FaMoon, FaSun } from "react-icons/fa";
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -10,6 +12,7 @@ const Navbar = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [userType, setUserType] = useState("");
   const navigate = useNavigate();
+  const { theme, toggleTheme } = useTheme();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -94,11 +97,14 @@ const Navbar = () => {
     });
   };
 
+  // Use CSS variables for text color for full dark/light support
+  const navTextColor = "text-[var(--text-main)]";
+  const navTextMuted = "text-[var(--text-muted)]";
+
   return (
     <header
-      className={`fixed w-full top-0 z-50 backdrop-blur-lg transition-all duration-400 ${
-        isScrolled ? "bg-black/60" : "bg-black/10"
-      }`}
+      className={`fixed w-full top-0 z-50 backdrop-blur-lg transition-all duration-400`}
+      style={{ background: "var(--nav-bg)" }}
     >
       <div className="flex justify-between items-center max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3">
         <motion.div
@@ -124,8 +130,6 @@ const Navbar = () => {
         <nav className="hidden md:flex items-center space-x-8">
           {navItems.map((item) => {
             const navPath = getNavPath(item);
-            const textColor = isLandingPage ? "text-white" : "text-black";
-
             return (
               <motion.div
                 key={item}
@@ -134,7 +138,7 @@ const Navbar = () => {
               >
                 <Link
                   to={navPath}
-                  className={`${textColor} text-lg font-semibold relative group transition-colors duration-300`}
+                  className={`text-lg font-semibold relative group transition-colors duration-300 ${navTextColor}`}
                   onClick={() => setTimeout(() => setCurrentPath(navPath), 100)}
                 >
                   <span className="transition-colors duration-300 hover:text-red-400">
@@ -146,6 +150,20 @@ const Navbar = () => {
             );
           })}
           
+          {/* Theme Toggle Button */}
+          <button
+            onClick={toggleTheme}
+            className="ml-4 p-2 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2"
+            aria-label="Toggle dark/light mode"
+            title="Toggle dark/light mode"
+          >
+            {theme === "light" ? (
+              <FaMoon className="text-xl" />
+            ) : (
+              <FaSun className="text-xl" />
+            )}
+          </button>
+
           {/* Auth Buttons */}
           <div className="flex items-center space-x-3 ml-6">
             {!isLoggedIn ? (
@@ -159,7 +177,7 @@ const Navbar = () => {
               </motion.button>
             ) : (
               <div className="flex items-center space-x-3">
-                <span className={`text-sm font-medium ${isLandingPage ? "text-white" : "text-gray-700"}`}>
+                <span className={`text-sm font-medium ${navTextMuted}`}>
                   Welcome, {userType}
                 </span>
                 <motion.button
@@ -213,13 +231,11 @@ const Navbar = () => {
             <ul className="flex flex-col items-center py-4 space-y-4">
               {navItems.map((item) => {
                 const navPath = getNavPath(item);
-                const textColor = isLandingPage ? "text-white" : "text-black";
-
                 return (
                   <motion.li key={item} className="text-lg font-semibold">
                     <Link
                       to={navPath}
-                      className={`${textColor} hover:text-red-400 transition-colors`}
+                      className={`${navTextColor} hover:text-red-400 transition-colors`}
                       onClick={() => {
                         setIsOpen(false);
                         setTimeout(() => setCurrentPath(navPath), 100);
@@ -231,6 +247,22 @@ const Navbar = () => {
                 );
               })}
               
+              {/* Theme Toggle Button (mobile) */}
+              <motion.li>
+                <button
+                  onClick={toggleTheme}
+                  className="p-2 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2"
+                  aria-label="Toggle dark/light mode"
+                  title="Toggle dark/light mode"
+                >
+                  {theme === "light" ? (
+                    <FaMoon className="text-xl" />
+                  ) : (
+                    <FaSun className="text-xl" />
+                  )}
+                </button>
+              </motion.li>
+
               {/* Mobile Auth Buttons */}
               <motion.li className="pt-2">
                 {!isLoggedIn ? (
@@ -247,7 +279,7 @@ const Navbar = () => {
                   </motion.button>
                 ) : (
                   <div className="flex flex-col items-center space-y-3">
-                    <span className={`text-sm font-medium ${isLandingPage ? "text-white" : "text-gray-700"}`}>
+                    <span className={`text-sm font-medium ${navTextMuted}`}>
                       Welcome, {userType}
                     </span>
                     <motion.button

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,13 +1,54 @@
 @import "tailwindcss";
 
+/* Theme CSS variables */
+:root {
+  --bg-main: #fff;
+  --bg-surface: #f9fafb;
+  --text-main: #18181b;
+  --text-muted: #6b7280;
+  --accent: #ef4444;
+  --nav-bg: rgba(255,255,255,0.8);
+}
+
+.dark {
+  --bg-main: #18181b;
+  --bg-surface: #23232b;
+  --text-main: #f4f4f5;
+  --text-muted: #a1a1aa;
+  --accent: #ef4444;
+  --nav-bg: rgba(24,24,27,0.95);
+}
+
+body, html {
+    background: var(--bg-main);
+    color: var(--text-main);
+    transition: background 0.3s, color 0.3s;
+    font-family: var(--font-montserrat), sans-serif;
+}
+
+header {
+  background: var(--nav-bg);
+  transition: background 0.3s;
+}
+
 @theme{
     --font-montserrat:"Montserrat", serif;
-
-    
     --color-primary:#C62E2E;
     --color-secondary:#F9F9F9;
     --color-calm:#0D92F4;
+}
 
+/* Optional: surface backgrounds for cards, panels, etc. */
+.bg-surface {
+  background: var(--bg-surface);
+}
+
+.text-accent {
+  color: var(--accent);
+}
+
+.text-muted {
+  color: var(--text-muted);
 }
 
 ::-webkit-scrollbar{

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { ThemeProvider } from './ThemeContext'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
+  </StrictMode>
 )


### PR DESCRIPTION
This PR introduces a toggle button to switch between dark and light themes. The selected theme is stored in localStorage, ensuring the user’s preference persists across sessions. Additionally, the theme is applied globally across all pages, maintaining a consistent UI experience throughout the site.

Here are screenshots:
![Screenshot 2025-06-19 205907](https://github.com/user-attachments/assets/4f9f83a8-881b-4721-923d-91ccd1641582)
![Screenshot 2025-06-19 205916](https://github.com/user-attachments/assets/d38d0620-4aca-4cea-a316-418566398839)
![Screenshot 2025-06-19 205926](https://github.com/user-attachments/assets/9c876d5a-ba3a-4687-a9e3-8ccc441f17c8)
![Screenshot 2025-06-19 205943](https://github.com/user-attachments/assets/63747be1-406c-4626-8b1f-11337b13ffa0)
![Screenshot 2025-06-19 205950](https://github.com/user-attachments/assets/6a54cb3f-3465-4020-8451-5af30df43851)
![Screenshot 2025-06-19 205958](https://github.com/user-attachments/assets/1b379d58-3e84-4737-b226-9e9c4a3e5f59)
![Screenshot 2025-06-19 210004](https://github.com/user-attachments/assets/d9d75eca-fc02-48f5-87be-30177ffbda50)
![Screenshot 2025-06-19 210016](https://github.com/user-attachments/assets/f5a3712d-50bf-4023-b335-f48fc4d3ff1a)
![Screenshot 2025-06-19 210024](https://github.com/user-attachments/assets/c16294a8-c913-4d93-b3b4-f670967474c2)
![Screenshot 2025-06-19 210031](https://github.com/user-attachments/assets/f6ba86a6-0193-42d7-a709-691e85c1be59)
![Screenshot 2025-06-19 210037](https://github.com/user-attachments/assets/0c2a09cc-7b5d-4804-9913-ef1aa530e592)
![Screenshot 2025-06-19 210046](https://github.com/user-attachments/assets/0e8b864b-8b6b-4031-bc28-883cdf844023)
![Screenshot 2025-06-19 210055](https://github.com/user-attachments/assets/3855c8d4-6ffe-47c5-bce1-e5e9a5beab80)
![Screenshot 2025-06-19 210102](https://github.com/user-attachments/assets/595b4a62-4d78-4902-808d-c71228f97e46)
